### PR TITLE
Dev

### DIFF
--- a/src/components/DashboardTabs/Channels.tsx
+++ b/src/components/DashboardTabs/Channels.tsx
@@ -103,6 +103,7 @@ export const Channels = ({ guildId, getTokenAction }: TabProps) => {
 							allChannels={
 								data?.success ? data.data.allChannels : null
 							}
+							guildId={guildId}
 						/>
 						<ChannelItem
 							settingName={channelLabels.announcementChannel!}
@@ -112,6 +113,7 @@ export const Channels = ({ guildId, getTokenAction }: TabProps) => {
 							allChannels={
 								data?.success ? data.data.allChannels : null
 							}
+							guildId={guildId}
 						/>
 						<ChannelItem
 							settingName={channelLabels.updatesChannel!}
@@ -121,6 +123,7 @@ export const Channels = ({ guildId, getTokenAction }: TabProps) => {
 							allChannels={
 								data?.success ? data.data.allChannels : null
 							}
+							guildId={guildId}
 						/>
 						<ChannelItem
 							settingName={channelLabels.logsChannel!}
@@ -130,6 +133,7 @@ export const Channels = ({ guildId, getTokenAction }: TabProps) => {
 							allChannels={
 								data?.success ? data.data.allChannels : null
 							}
+							guildId={guildId}
 						/>
 					</ul>
 				)}

--- a/src/components/DashboardTabs/EditForms/ChannelItem.tsx
+++ b/src/components/DashboardTabs/EditForms/ChannelItem.tsx
@@ -22,12 +22,14 @@ export const ChannelItem = ({
 	channelId,
 	type,
 	allChannels,
+	guildId,
 }: {
 	settingName: string;
 	channelName: string | null;
 	channelId: string | null;
 	type: "welcome" | "announcement" | "updates" | "logs";
 	allChannels?: RESTGetAPIGuildChannelsResult | null;
+	guildId: string;
 }) => {
 	const { getToken } = useAuth();
 	const [editing, setEditing] = useState<boolean>(false);
@@ -42,7 +44,7 @@ export const ChannelItem = ({
 		mutationFn: async () => {
 			const token = await getToken();
 			const res = await client.dash.setChannel.$post(
-				{ guildId: "1", type, channelId: channel.id! },
+				{ guildId: guildId, type, channelId: channel.id! },
 				{
 					headers: {
 						Authorization: `Bearer ${token}`,


### PR DESCRIPTION
This pull request enhances the `Channels` and `ChannelItem` components in the dashboard by introducing support for `guildId` and improving the channel selection and saving experience. The changes ensure better data handling and user feedback during channel editing.

### Enhancements to `Channels` Component:
* Added the `guildId` prop to all instances of `ChannelItem` within the `Channels` component, enabling the component to pass the guild identifier for API interactions. [[1]](diffhunk://#diff-76e9f2b1a84a186378684c0abced0d1e5ffe2d2e54f66fd401cc2fde53ae8db9R106) [[2]](diffhunk://#diff-76e9f2b1a84a186378684c0abced0d1e5ffe2d2e54f66fd401cc2fde53ae8db9R116) [[3]](diffhunk://#diff-76e9f2b1a84a186378684c0abced0d1e5ffe2d2e54f66fd401cc2fde53ae8db9R126) [[4]](diffhunk://#diff-76e9f2b1a84a186378684c0abced0d1e5ffe2d2e54f66fd401cc2fde53ae8db9R136)

### Improvements to `ChannelItem` Component:
* Introduced the `guildId` prop to the `ChannelItem` component and updated API calls to use the passed `guildId` instead of a hardcoded value.
* Added a `saving` state to provide user feedback during save operations and disabled the save button while saving is in progress. [[1]](diffhunk://#diff-9a927843ad7447a8f4c67ca737924b5bd55dbeff6f33584879cfbcb033e22df5R58) [[2]](diffhunk://#diff-9a927843ad7447a8f4c67ca737924b5bd55dbeff6f33584879cfbcb033e22df5L118-R133)
* Removed the `handleSave` function and directly integrated the save logic into the button's `onClick` handler for better readability and state management.
* Enhanced the `Select` dropdown to update the local channel state when a new channel is selected, improving the user experience during channel editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel selection and saving now correctly use the associated guild for updates.
  * The save button is disabled while changes are being saved, providing clearer feedback during the process.

* **Bug Fixes**
  * Fixed issue where channel updates were previously sent to a default guild instead of the selected one.

* **Improvements**
  * Enhanced state management for channel selection and saving actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->